### PR TITLE
Detect TAG_EDITMSG as gitcommit

### DIFF
--- a/ftdetect/git.vim
+++ b/ftdetect/git.vim
@@ -1,5 +1,5 @@
 " Git
-autocmd BufNewFile,BufRead *.git/COMMIT_EDITMSG                set ft=gitcommit
+autocmd BufNewFile,BufRead *.git/{COMMIT,TAG}_EDITMSG          set ft=gitcommit
 autocmd BufNewFile,BufRead *.git/config,.gitconfig,.gitmodules set ft=gitconfig
 autocmd BufNewFile,BufRead git-rebase-todo                     set ft=gitrebase
 autocmd BufNewFile,BufRead .msg.[0-9]*


### PR DESCRIPTION
y/n?

I tend to write (some) tags in the same subject-body format as commits. There's also NOTES_EDITMSG, but I don't think that the commit style really lends itself to that so I left it out.
