### PR TITLE
Detect commit messages in submodules

### DIFF
--- a/ftdetect/git.vim
+++ b/ftdetect/git.vim
@@ -1,5 +1,6 @@
 " Git
 autocmd BufNewFile,BufRead *.git/COMMIT_EDITMSG                set ft=gitcommit
+autocmd BufNewFile,BufRead *.git/modules/**/COMMIT_EDITMSG     set ft=gitcommit
 autocmd BufNewFile,BufRead *.git/config,.gitconfig,.gitmodules set ft=gitconfig
 autocmd BufNewFile,BufRead git-rebase-todo                     set ft=gitrebase
 autocmd BufNewFile,BufRead .msg.[0-9]*


### PR DESCRIPTION
Since git 1.7.8, the `$GIT_DIR` for submodules is created under `$GIT_DIR/modules/<name>` (see [here](https://github.com/gitster/git/blob/master/Documentation/RelNotes/1.7.8.txt#L109-L114) for more info). This means that `COMMIT_EDITMSG` is also placed there, and it's not detected with the `gitcommit` filetype. This pull request fixes that.
