### PR TITLE
`--no-ext-diff` on git diffs

### DIFF
--- a/ftplugin/gitcommit.vim
+++ b/ftplugin/gitcommit.vim
@@ -58,7 +58,7 @@ function! s:gitdiffcached(bang,gitdir,...)
   else
     let extra = "-p --stat=".&columns
   endif
-  call system(git." diff --cached --no-color ".extra." > ".(exists("*shellescape") ? shellescape(name) : name))
+  call system(git." diff --cached --no-color --no-ext-diff ".extra." > ".(exists("*shellescape") ? shellescape(name) : name))
   exe "pedit ".(exists("*fnameescape") ? fnameescape(name) : name)
   wincmd P
   let b:git_dir = a:gitdir


### PR DESCRIPTION
diffs aren't presented correctly unless `--no-ext-diff` is on under some circumstances.

In my situation, I set up git diff to run vimdiff on the two files. Then, I set up my .vimrc to show me the diff during a git commit like this: http://vimbits.com/bits/173

The diff wasn't displayed correctly because it was trying to run vimdiff instead of just printing the standard git diff.
