### PR TITLE
Ignore Pathogen-generated help tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
This is useful if you use Pathogen along with a Git-managed `.vim` directory where your plugin bundles are submodules. When you run `:Helptags` (or otherwise ask Pathogen to generate your help tags) it creates a file `doc/tags` inside the `vim-git` submodule—which causes Git to mark the submodule as dirty.

This is obnoxious, so this change tells Git to ignore that file. If you ever wanted to distribute a tag file for some reason, you could just take it back out of `.gitignore`.
