### PR TITLE
ftdetect/git.vim: Fix gitsendemail detection

### DIFF
--- a/ftdetect/git.vim
+++ b/ftdetect/git.vim
@@ -4,10 +4,7 @@ autocmd BufNewFile,BufRead *.git/config,.gitconfig,.gitmodules set ft=gitconfig
 autocmd BufNewFile,BufRead */.config/git/config                set ft=gitconfig
 autocmd BufNewFile,BufRead *.git/modules/**/config             set ft=gitconfig
 autocmd BufNewFile,BufRead git-rebase-todo                     set ft=gitrebase
-autocmd BufNewFile,BufRead .msg.[0-9]*
-      \ if getline(1) =~ '^From.*# This line is ignored.$' |
-      \   set ft=gitsendemail |
-      \ endif
+autocmd BufNewFile,BufRead .gitsendemail.*                     set ft=gitsendemail
 autocmd BufNewFile,BufRead *.git/**
       \ if getline(1) =~ '^\x\{40\}\>\|^ref: ' |
       \   set ft=git |


### PR DESCRIPTION
In modern versions of git send-email, messages are named
.gitsendemail.msg.([a-zA-Z0-9]|_)\* (I haven't read the code to be sure
there aren't more options for the unique identifier), but currently the
file detection assumes that they are named .msg.[0-9]_, obviously this
regex will not match. The easiest solution is just to look for
.gitsendemail._

Signed-off-by: Dylan Baker baker.dylan.c@gmail.com
