### PR TITLE
vim-git: add support for git-send-email --annotate

### DIFF
--- a/ftdetect/git.vim
+++ b/ftdetect/git.vim
@@ -10,6 +10,11 @@ autocmd BufNewFile,BufRead *.git/**
       \   set ft=git |
       \ endif
 
+autocmd BufNewFile,BufRead *
+      \ if getline(1) =~ '^From \x\{40\} Mon Sep 17 00:00:00 2001$' |
+      \   set filetype=gitsendemail |
+      \ endif
+
 " This logic really belongs in scripts.vim
 autocmd BufNewFile,BufRead,StdinReadPost *
       \ if getline(1) =~ '^\(commit\|tree\|object\) \x\{40\}\>\|^tag \S\+$' |

--- a/syntax/gitsendemail.vim
+++ b/syntax/gitsendemail.vim
@@ -9,11 +9,16 @@ if exists("b:current_syntax")
 endif
 
 runtime! syntax/mail.vim
+unlet b:current_syntax
+
 syn case match
 
 syn match   gitsendemailComment "\%^From.*#.*"
 syn match   gitsendemailComment "^GIT:.*"
 
 hi def link gitsendemailComment Comment
+
+syn include @gitsendemailDiff syntax/diff.vim
+syn region gitsendemailDiff start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^-- %/ fold contains=@gitsendemailDiff
 
 let b:current_syntax = "gitsendemail"


### PR DESCRIPTION
Taking the diff.vim and mail.vim settings, create a git-format-patch
filetype which uses settings to show syntax highlighted diffs as well as
proper mail message format. Include a text width so that correct
paragraph formatting is also used. The primary purpose for this change is for use of the --annotate and --cover-letter options of git-send-email for editing a format-patch file.

Signed-off-by: Jacob Keller jacob.keller@gmail.com
