### PR TITLE
Adding "gitconfig" (without the dot) to the filetypes

### DIFF
--- a/ftdetect/git.vim
+++ b/ftdetect/git.vim
@@ -1,10 +1,10 @@
 " Git
 autocmd BufNewFile,BufRead *.git/{,modules/**/}{COMMIT_EDIT,TAG_EDIT,MERGE_,}MSG set ft=gitcommit
-autocmd BufNewFile,BufRead *.git/config,.gitconfig,.gitmodules set ft=gitconfig
-autocmd BufNewFile,BufRead */.config/git/config                set ft=gitconfig
-autocmd BufNewFile,BufRead *.git/modules/**/config             set ft=gitconfig
-autocmd BufNewFile,BufRead git-rebase-todo                     set ft=gitrebase
-autocmd BufNewFile,BufRead .gitsendemail.*                     set ft=gitsendemail
+autocmd BufNewFile,BufRead *.git/config,.gitconfig,gitconfig,.gitmodules set ft=gitconfig
+autocmd BufNewFile,BufRead */.config/git/config                          set ft=gitconfig
+autocmd BufNewFile,BufRead *.git/modules/**/config                       set ft=gitconfig
+autocmd BufNewFile,BufRead git-rebase-todo                               set ft=gitrebase
+autocmd BufNewFile,BufRead .gitsendemail.*                               set ft=gitsendemail
 autocmd BufNewFile,BufRead *.git/**
       \ if getline(1) =~ '^\x\{40\}\>\|^ref: ' |
       \   set ft=git |


### PR DESCRIPTION
vim-git/syntax/gitconfig.vim states under filenames that it should be included, but doesn't seem to be.