### PR TITLE
Syntax updates

### DIFF
--- a/syntax/gitcommit.vim
+++ b/syntax/gitcommit.vim
@@ -15,44 +15,60 @@ if has("spell")
   syn spell toplevel
 endif
 
-syn include @gitcommitDiff syntax/diff.vim
-syn region gitcommitDiff start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|#\)\@=/ fold contains=@gitcommitDiff
+if exists("g:git_comment_char")
+  if g:git_comment_char == "auto"
+    let s:comment_char = substitute(system("git config core.commentchar"), '\n$', "", "")
+    if s:comment_char == ""
+      let s:comment_char = "#"
+    endif
+  else
+    let s:comment_char = g:git_comment_char
+  endif
+  if s:comment_char == '\\' || s:comment_char == '^'
+    let s:comment_char = '\' . s:comment_char
+  endif
+else
+  let s:comment_char = "#"
+endif
 
-syn match   gitcommitFirstLine	"\%^[^#].*"  nextgroup=gitcommitBlank skipnl
-syn match   gitcommitSummary	"^.\{0,50\}" contained containedin=gitcommitFirstLine nextgroup=gitcommitOverflow contains=@Spell
-syn match   gitcommitOverflow	".*" contained contains=@Spell
-syn match   gitcommitBlank	"^[^#].*" contained contains=@Spell
-syn match   gitcommitComment	"^#.*"
-syn match   gitcommitHead	"^\%(#   .*\n\)\+#$" contained transparent
-syn match   gitcommitOnBranch	"\%(^# \)\@<=On branch" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite
-syn match   gitcommitOnBranch	"\%(^# \)\@<=Your branch .\{-\} '" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite
-syn match   gitcommitBranch	"[^ ']\+" contained
-syn match   gitcommitNoBranch	"\%(^# \)\@<=Not currently on any branch." contained containedin=gitcommitComment
-syn match   gitcommitHeader	"\%(^# \)\@<=.*:$"	contained containedin=gitcommitComment
-syn region  gitcommitAuthor	matchgroup=gitCommitHeader start=/\%(^# \)\@<=\%(Author\|Committer\):/ end=/$/ keepend oneline contained containedin=gitcommitComment transparent
-syn match   gitcommitNoChanges	"\%(^# \)\@<=No changes$" contained containedin=gitcommitComment
+syn       include @gitcommitDiff syntax/diff.vim
+exec 'syn region gitcommitDiff start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|[' . s:comment_char . ']\)\@=/ fold contains=@gitcommitDiff'
 
-syn region  gitcommitUntracked	start=/^# Untracked files:/ end=/^#$\|^#\@!/ contains=gitcommitHeader,gitcommitHead,gitcommitUntrackedFile fold
-syn match   gitcommitUntrackedFile  "\t\@<=.*"	contained
+exec 'syn match   gitcommitFirstLine	"\%^[^' . s:comment_char . '].*"  nextgroup=gitcommitBlank skipnl'
+syn       match   gitcommitSummary	"^.\{0,50\}" contained containedin=gitcommitFirstLine nextgroup=gitcommitOverflow contains=@Spell
+syn       match   gitcommitOverflow	".*" contained contains=@Spell
+exec 'syn match   gitcommitBlank	"^[^' . s:comment_char . '].*" contained contains=@Spell'
+exec 'syn match   gitcommitComment	"^[' . s:comment_char . '].*"'
+exec 'syn match   gitcommitHead	"^\%([' . s:comment_char . ']   .*\n\)\+[' . s:comment_char . ']$" contained transparent'
+exec 'syn match   gitcommitOnBranch	"\%(^[' . s:comment_char . '] \)\@<=On branch" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite'
+exec 'syn match   gitcommitOnBranch	"\%(^[' . s:comment_char . '] \)\@<=Your branch .\{-\} ''" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite'
+syn       match   gitcommitBranch	"[^ ']\+" contained
+exec 'syn match   gitcommitNoBranch	"\%(^[' . s:comment_char . '] \)\@<=Not currently on any branch." contained containedin=gitcommitComment'
+exec 'syn match   gitcommitHeader	"\%(^[' . s:comment_char . '] \)\@<=.*:$"	contained containedin=gitcommitComment'
+exec 'syn region  gitcommitAuthor	matchgroup=gitCommitHeader start=/\%(^[' . s:comment_char . '] \)\@<=\%(Author\|Committer\):/ end=/$/ keepend oneline contained containedin=gitcommitComment transparent'
+exec 'syn match   gitcommitNoChanges	"\%(^[' . s:comment_char . '] \)\@<=No changes$" contained containedin=gitcommitComment'
 
-syn region  gitcommitDiscarded	start=/^# Change\%(s not staged for commit\|d but not updated\):/ end=/^#$\|^#\@!/ contains=gitcommitHeader,gitcommitHead,gitcommitDiscardedType fold
-syn region  gitcommitSelected	start=/^# Changes to be committed:/ end=/^#$\|^#\@!/ contains=gitcommitHeader,gitcommitHead,gitcommitSelectedType fold
-syn region  gitcommitUnmerged	start=/^# Unmerged paths:/ end=/^#$\|^#\@!/ contains=gitcommitHeader,gitcommitHead,gitcommitUnmergedType fold
+exec 'syn region  gitcommitUntracked	start=/^[' . s:comment_char . '] Untracked files:/ end=/^[' . s:comment_char . ']$\|^[' . s:comment_char . ']\@!/ contains=gitcommitHeader,gitcommitHead,gitcommitUntrackedFile fold'
+syn       match   gitcommitUntrackedFile  "\t\@<=.*"	contained
+
+exec 'syn region  gitcommitDiscarded	start=/^[' . s:comment_char . '] Change\%(s not staged for commit\|d but not updated\):/ end=/^[' . s:comment_char . ']$\|^[' . s:comment_char . ']\@!/ contains=gitcommitHeader,gitcommitHead,gitcommitDiscardedType fold'
+exec 'syn region  gitcommitSelected	start=/^[' . s:comment_char . '] Changes to be committed:/ end=/^[' . s:comment_char . ']$\|^[' . s:comment_char . ']\@!/ contains=gitcommitHeader,gitcommitHead,gitcommitSelectedType fold'
+exec 'syn region  gitcommitUnmerged	start=/^[' . s:comment_char . '] Unmerged paths:/ end=/^[' . s:comment_char . ']$\|^[' . s:comment_char . ']\@!/ contains=gitcommitHeader,gitcommitHead,gitcommitUnmergedType fold'
 
 
-syn match   gitcommitDiscardedType	"\t\@<=[[:lower:]][^:]*[[:lower:]]: "he=e-2	contained containedin=gitcommitComment nextgroup=gitcommitDiscardedFile skipwhite
-syn match   gitcommitSelectedType	"\t\@<=[[:lower:]][^:]*[[:lower:]]: "he=e-2	contained containedin=gitcommitComment nextgroup=gitcommitSelectedFile skipwhite
-syn match   gitcommitUnmergedType	"\t\@<=[[:lower:]][^:]*[[:lower:]]: "he=e-2	contained containedin=gitcommitComment nextgroup=gitcommitUnmergedFile skipwhite
-syn match   gitcommitDiscardedFile	".\{-\}\%($\| -> \)\@=" contained nextgroup=gitcommitDiscardedArrow
-syn match   gitcommitSelectedFile	".\{-\}\%($\| -> \)\@=" contained nextgroup=gitcommitSelectedArrow
-syn match   gitcommitUnmergedFile	".\{-\}\%($\| -> \)\@=" contained nextgroup=gitcommitSelectedArrow
-syn match   gitcommitDiscardedArrow	" -> " contained nextgroup=gitcommitDiscardedFile
-syn match   gitcommitSelectedArrow	" -> " contained nextgroup=gitcommitSelectedFile
-syn match   gitcommitUnmergedArrow	" -> " contained nextgroup=gitcommitSelectedFile
+syn       match   gitcommitDiscardedType	"\t\@<=[[:lower:]][^:]*[[:lower:]]: "he=e-2	contained containedin=gitcommitComment nextgroup=gitcommitDiscardedFile skipwhite
+syn       match   gitcommitSelectedType	"\t\@<=[[:lower:]][^:]*[[:lower:]]: "he=e-2	contained containedin=gitcommitComment nextgroup=gitcommitSelectedFile skipwhite
+syn       match   gitcommitUnmergedType	"\t\@<=[[:lower:]][^:]*[[:lower:]]: "he=e-2	contained containedin=gitcommitComment nextgroup=gitcommitUnmergedFile skipwhite
+syn       match   gitcommitDiscardedFile	".\{-\}\%($\| -> \)\@=" contained nextgroup=gitcommitDiscardedArrow
+syn       match   gitcommitSelectedFile	".\{-\}\%($\| -> \)\@=" contained nextgroup=gitcommitSelectedArrow
+syn       match   gitcommitUnmergedFile	".\{-\}\%($\| -> \)\@=" contained nextgroup=gitcommitSelectedArrow
+syn       match   gitcommitDiscardedArrow	" -> " contained nextgroup=gitcommitDiscardedFile
+syn       match   gitcommitSelectedArrow	" -> " contained nextgroup=gitcommitSelectedFile
+syn       match   gitcommitUnmergedArrow	" -> " contained nextgroup=gitcommitSelectedFile
 
-syn match   gitcommitWarning		"\%^[^#].*: needs merge$" nextgroup=gitcommitWarning skipnl
-syn match   gitcommitWarning		"^[^#].*: needs merge$" nextgroup=gitcommitWarning skipnl contained
-syn match   gitcommitWarning		"^\%(no changes added to commit\|nothing \%(added \)\=to commit\)\>.*\%$"
+exec 'syn match   gitcommitWarning		"\%^[^' . s:comment_char . '].*: needs merge$" nextgroup=gitcommitWarning skipnl'
+exec 'syn match   gitcommitWarning		"^[^' . s:comment_char . '].*: needs merge$" nextgroup=gitcommitWarning skipnl contained'
+syn       match   gitcommitWarning		"^\%(no changes added to commit\|nothing \%(added \)\=to commit\)\>.*\%$"
 
 hi def link gitcommitSummary		Keyword
 hi def link gitcommitComment		Comment

--- a/syntax/gitcommit.vim
+++ b/syntax/gitcommit.vim
@@ -40,25 +40,25 @@ syn       match   gitcommitOverflow	".*" contained contains=@Spell
 exec 'syn match   gitcommitBlank	"^[^' . s:comment_char . '].*" contained contains=@Spell'
 exec 'syn match   gitcommitComment	"^[' . s:comment_char . '].*"'
 exec 'syn match   gitcommitHead	"^\%([' . s:comment_char . ']   .*\n\)\+[' . s:comment_char . ']$" contained transparent'
-exec 'syn match   gitcommitOnBranch	"\%(^[' . s:comment_char . '] \)\@<=On branch" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite'
-exec 'syn match   gitcommitOnBranch	"\%(^[' . s:comment_char . '] \)\@<=Your branch .\{-\} ''" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite'
+exec 'syn match   gitcommitOnBranch	"^[' . s:comment_char . '] \zsOn branch" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite'
+exec 'syn match   gitcommitOnBranch	"^[' . s:comment_char . '] \zsYour branch .\{-\} ''" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite'
 syn       match   gitcommitBranch	"[^ ']\+" contained
-exec 'syn match   gitcommitNoBranch	"\%(^[' . s:comment_char . '] \)\@<=Not currently on any branch." contained containedin=gitcommitComment'
-exec 'syn match   gitcommitHeader	"\%(^[' . s:comment_char . '] \)\@<=.*:$"	contained containedin=gitcommitComment'
-exec 'syn region  gitcommitAuthor	matchgroup=gitCommitHeader start=/\%(^[' . s:comment_char . '] \)\@<=\%(Author\|Committer\):/ end=/$/ keepend oneline contained containedin=gitcommitComment transparent'
-exec 'syn match   gitcommitNoChanges	"\%(^[' . s:comment_char . '] \)\@<=No changes$" contained containedin=gitcommitComment'
+exec 'syn match   gitcommitNoBranch	"^[' . s:comment_char . '] \zsNot currently on any branch." contained containedin=gitcommitComment'
+exec 'syn match   gitcommitHeader	"^[' . s:comment_char . '] \zs.*:$"	contained containedin=gitcommitComment'
+exec 'syn region  gitcommitAuthor	matchgroup=gitCommitHeader start=/^[' . s:comment_char . '] \zs\%(Author\|Committer\):/ end=/$/ keepend oneline contained containedin=gitcommitComment transparent'
+exec 'syn match   gitcommitNoChanges	"^[' . s:comment_char . '] \zsNo changes$" contained containedin=gitcommitComment'
 
 exec 'syn region  gitcommitUntracked	start=/^[' . s:comment_char . '] Untracked files:/ end=/^[' . s:comment_char . ']$\|^[' . s:comment_char . ']\@!/ contains=gitcommitHeader,gitcommitHead,gitcommitUntrackedFile fold'
-syn       match   gitcommitUntrackedFile  "\t\@<=.*"	contained
+syn       match   gitcommitUntrackedFile  "\t\zs.*"	contained
 
 exec 'syn region  gitcommitDiscarded	start=/^[' . s:comment_char . '] Change\%(s not staged for commit\|d but not updated\):/ end=/^[' . s:comment_char . ']$\|^[' . s:comment_char . ']\@!/ contains=gitcommitHeader,gitcommitHead,gitcommitDiscardedType fold'
 exec 'syn region  gitcommitSelected	start=/^[' . s:comment_char . '] Changes to be committed:/ end=/^[' . s:comment_char . ']$\|^[' . s:comment_char . ']\@!/ contains=gitcommitHeader,gitcommitHead,gitcommitSelectedType fold'
 exec 'syn region  gitcommitUnmerged	start=/^[' . s:comment_char . '] Unmerged paths:/ end=/^[' . s:comment_char . ']$\|^[' . s:comment_char . ']\@!/ contains=gitcommitHeader,gitcommitHead,gitcommitUnmergedType fold'
 
 
-syn       match   gitcommitDiscardedType	"\t\@<=[[:lower:]][^:]*[[:lower:]]: "he=e-2	contained containedin=gitcommitComment nextgroup=gitcommitDiscardedFile skipwhite
-syn       match   gitcommitSelectedType	"\t\@<=[[:lower:]][^:]*[[:lower:]]: "he=e-2	contained containedin=gitcommitComment nextgroup=gitcommitSelectedFile skipwhite
-syn       match   gitcommitUnmergedType	"\t\@<=[[:lower:]][^:]*[[:lower:]]: "he=e-2	contained containedin=gitcommitComment nextgroup=gitcommitUnmergedFile skipwhite
+syn       match   gitcommitDiscardedType	"\t\zs[[:lower:]][^:]*[[:lower:]]: "he=e-2	contained containedin=gitcommitComment nextgroup=gitcommitDiscardedFile skipwhite
+syn       match   gitcommitSelectedType	"\t\zs[[:lower:]][^:]*[[:lower:]]: "he=e-2	contained containedin=gitcommitComment nextgroup=gitcommitSelectedFile skipwhite
+syn       match   gitcommitUnmergedType	"\t\zs[[:lower:]][^:]*[[:lower:]]: "he=e-2	contained containedin=gitcommitComment nextgroup=gitcommitUnmergedFile skipwhite
 syn       match   gitcommitDiscardedFile	".\{-\}\%($\| -> \)\@=" contained nextgroup=gitcommitDiscardedArrow
 syn       match   gitcommitSelectedFile	".\{-\}\%($\| -> \)\@=" contained nextgroup=gitcommitSelectedArrow
 syn       match   gitcommitUnmergedFile	".\{-\}\%($\| -> \)\@=" contained nextgroup=gitcommitSelectedArrow

--- a/syntax/gitconfig.vim
+++ b/syntax/gitconfig.vim
@@ -14,9 +14,9 @@ syn case ignore
 syn sync minlines=10
 
 syn match   gitconfigComment	"[#;].*"
-syn match   gitconfigSection	"\%(^\s*\)\@<=\[[a-z0-9.-]\+\]"
-syn match   gitconfigSection	'\%(^\s*\)\@<=\[[a-z0-9.-]\+ \+\"\%([^\\"]\|\\.\)*"\]'
-syn match   gitconfigVariable	 "\%(^\s*\)\@<=\a\k*\%(\s*\%([=#;]\|$\)\)\@=" nextgroup=gitconfigAssignment skipwhite
+syn match   gitconfigSection	"^\s*\zs\[[a-z0-9.-]\+\]"
+syn match   gitconfigSection	'^\s*\zs\[[a-z0-9.-]\+ \+\"\%([^\\"]\|\\.\)*"\]'
+syn match   gitconfigVariable	 "^\s*\zs\a\k*\%(\s*\%([=#;]\|$\)\)\@=" nextgroup=gitconfigAssignment skipwhite
 syn region  gitconfigAssignment  matchgroup=gitconfigNone start=+=\s*+ skip=+\\+ end=+\s*$+ contained contains=gitconfigBoolean,gitconfigNumber,gitConfigString,gitConfigEscape,gitConfigError,gitconfigComment keepend
 syn keyword gitconfigBoolean true false yes no contained
 syn match   gitconfigNumber  "\d\+" contained


### PR DESCRIPTION
Update `syntax/gitcommit.vim` to handle a customized git `core.commentChar`, and update both `syntax/gitconfig.vim` and `syntax/gitcommit.vim` to remove `\@<=`  backreferences in favor of `\zs`.
