### PR TITLE
Recognise commits from inside worktrees

### DIFF
--- a/ftdetect/git.vim
+++ b/ftdetect/git.vim
@@ -1,5 +1,5 @@
 " Git
-autocmd BufNewFile,BufRead *.git/{,modules/**/}{COMMIT_EDIT,TAG_EDIT,MERGE_,}MSG set ft=gitcommit
+autocmd BufNewFile,BufRead *.git/{,modules/**/,worktrees/*/}{COMMIT_EDIT,TAG_EDIT,MERGE_,}MSG set ft=gitcommit
 autocmd BufNewFile,BufRead *.git/config,.gitconfig,gitconfig,.gitmodules set ft=gitconfig
 autocmd BufNewFile,BufRead */.config/git/config                          set ft=gitconfig
 autocmd BufNewFile,BufRead *.git/modules/**/config                       set ft=gitconfig


### PR DESCRIPTION
Work trees don't have their own config, so this seems to be the only thing that needs to know about them.