### PR TITLE
Use shiftwidth() function instead of &sw

### DIFF
--- a/indent/gitconfig.vim
+++ b/indent/gitconfig.vim
@@ -24,13 +24,13 @@ function! GetGitconfigIndent()
   let cline = getline(v:lnum)
   if line =~  '\\\@<!\%(\\\\\)*\\$'
     " odd number of slashes, in a line continuation
-    return 2 * &sw
+    return 2 * shiftwidth()
   elseif cline =~ '^\s*\['
     return 0
   elseif cline =~ '^\s*\a'
-    return &sw
+    return shiftwidth()
   elseif cline == ''       && line =~ '^\['
-    return &sw
+    return shiftwidth()
   else
     return -1
   endif

--- a/indent/gitconfig.vim
+++ b/indent/gitconfig.vim
@@ -19,18 +19,30 @@ if exists("*GetGitconfigIndent")
   finish
 endif
 
+" The shiftwidth() exists since patch 7.3.694
+" Don't require it to exist.
+if exists('*shiftwidth')
+  function s:sw() abort
+    return shiftwidth()
+  endfunction
+else
+  function s:sw() abort
+    return &shiftwidth
+  endfunction
+endif
+
 function! GetGitconfigIndent()
   let line  = getline(prevnonblank(v:lnum-1))
   let cline = getline(v:lnum)
   if line =~  '\\\@<!\%(\\\\\)*\\$'
     " odd number of slashes, in a line continuation
-    return 2 * shiftwidth()
+    return 2 * s:sw()
   elseif cline =~ '^\s*\['
     return 0
   elseif cline =~ '^\s*\a'
-    return shiftwidth()
+    return s:sw()
   elseif cline == ''       && line =~ '^\['
-    return shiftwidth()
+    return s:sw()
   else
     return -1
   endif


### PR DESCRIPTION
See https://github.com/vim/vim/pull/578 for details.

> With set shiftwidth=0, gg=G in filetype=vim buffer will result in removing all indents.
> Because indent/vim.vim doesn't use shiftwidth() instead of accessing &sw directly.

This is same as vim-git.