### PR TITLE
Remove one flag from formatoptions at a time

### DIFF
--- a/ftplugin/gitcommit.vim
+++ b/ftplugin/gitcommit.vim
@@ -11,7 +11,8 @@ endif
 runtime! ftplugin/git.vim
 let b:did_ftplugin = 1
 
-setlocal nomodeline tabstop=8 formatoptions-=croq formatoptions+=tl textwidth=72
+setlocal nomodeline tabstop=8 formatoptions+=tl textwidth=72
+setlocal formatoptions-=c formatoptions-=r formatoptions-=o formatoptions-=q
 let b:undo_ftplugin = 'setl modeline< tabstop< formatoptions< tw<'
 
 if exists("g:no_gitcommit_commands") || v:version < 700


### PR DESCRIPTION
See `:help remove-option-flags`. `setlocal formatoptions-=croq` searches 'formatoptions' for exact "croq", so "c", "r", "o", or "q" flag won't be removed if 'formatoptions' is "crqo", "cro", "crotq", etc.