### PR TITLE
Support leading whitespace in rebase -i comments

### DIFF
--- a/syntax/gitrebase.vim
+++ b/syntax/gitrebase.vim
@@ -21,7 +21,7 @@ syn match   gitrebaseExec   "\v^%(x|exec)>" nextgroup=gitrebaseCommand skipwhite
 syn match   gitrebaseDrop   "\v^d%(rop)=>"   nextgroup=gitrebaseCommit skipwhite
 syn match   gitrebaseSummary ".*"               contains=gitrebaseHash contained
 syn match   gitrebaseCommand ".*"                                      contained
-syn match   gitrebaseComment "^#.*"             contains=gitrebaseHash
+syn match   gitrebaseComment "^\s*#.*"             contains=gitrebaseHash
 syn match   gitrebaseSquashError "\v%^%(s%(quash)=>|f%(ixup)=>)" nextgroup=gitrebaseCommit skipwhite
 
 hi def link gitrebaseCommit         gitrebaseHash


### PR DESCRIPTION
When rebasing interactively, Git ignores leading whitespace in front of
the comment character. At time of writing (a42d7b6 of Git):

    git-rebase--interactive.sh:566:
    ...
    read -r command sha1 rest < "$todo"
    ...

At this point, IFS is unset and thus whitespace ignored. This commit
updates the interactive rebase syntax to correctly recognise this
scenario.