### PR TITLE
Accept ranges for choose commands

### DIFF
--- a/ftplugin/gitrebase.vim
+++ b/ftplugin/gitrebase.vim
@@ -18,19 +18,19 @@ if !exists("b:undo_ftplugin")
 endif
 let b:undo_ftplugin = b:undo_ftplugin."|setl com< cms< fo< ml<"
 
-function! s:choose(word)
-  s/^\(\w\+\>\)\=\(\s*\)\ze\x\{4,40\}\>/\=(strlen(submatch(1)) == 1 ? a:word[0] : a:word) . substitute(submatch(2),'^$',' ','')/e
+function! s:choose(word, line1, line2)
+  execute a:line1 . ',' . a:line2 . "s/^\\(\\w\\+\\>\\)\\=\\(\\s*\\)\\ze\\x\\{4,40\\}\\>/\\=(strlen(submatch(1)) == 1 ? a:word[0] : a:word) . substitute(submatch(2),'^$',' ','')/e"
 endfunction
 
 function! s:cycle()
   call s:choose(get({'s':'edit','p':'squash','e':'reword','r':'fixup'},getline('.')[0],'pick'))
 endfunction
 
-command! -buffer -bar Pick   :call s:choose('pick')
-command! -buffer -bar Squash :call s:choose('squash')
-command! -buffer -bar Edit   :call s:choose('edit')
-command! -buffer -bar Reword :call s:choose('reword')
-command! -buffer -bar Fixup  :call s:choose('fixup')
+command! -buffer -bar -range Pick   :call s:choose('pick', <line1>, <line2>)
+command! -buffer -bar -range Squash :call s:choose('squash', <line1>, <line2>)
+command! -buffer -bar -range Edit   :call s:choose('edit', <line1>, <line2>)
+command! -buffer -bar -range Reword :call s:choose('reword', <line1>, <line2>)
+command! -buffer -bar -range Fixup  :call s:choose('fixup', <line1>, <line2>)
 command! -buffer -bar Cycle  :call s:cycle()
 " The above are more useful when they are mapped; for example:
 "nnoremap <buffer> <silent> S :Cycle<CR>


### PR DESCRIPTION
This allows you to visually select a region and run `:'<,'>Fixup` to
replace all instances in the range.