### PR TITLE
Fix highlighting "git log --parents"

### DIFF
--- a/syntax/git.vim
+++ b/syntax/git.vim
@@ -13,7 +13,7 @@ syn sync minlines=50
 syn include @gitDiff syntax/diff.vim
 
 syn region gitHead start=/\%^/ end=/^$/
-syn region gitHead start=/\%(^commit \x\{40\}\%(\s*(.*)\)\=$\)\@=/ end=/^$/
+syn region gitHead start=/\%(^commit\%( \x\{40\}\)\{1,\}\%(\s*(.*)\)\=$\)\@=/ end=/^$/
 
 " For git reflog and git show ...^{tree}, avoid sync issues
 syn match gitHead /^\d\{6\} \%(\w\{4} \)\=\x\{40\}\%( [0-3]\)\=\t.*/


### PR DESCRIPTION
When passing the "--parents" options to "git log" two commit hashes are
shown in the commit header in the log; since this case is not covered by
vim syntax/git.vim, the highlighting does not work.

Fix this by matching the commit hash, and the leading space, *at least*
once instead of *exactly* once.