### PR TITLE
Support `commit.cleanup scissors` configuraiton

### DIFF
--- a/syntax/gitcommit.vim
+++ b/syntax/gitcommit.vim
@@ -22,7 +22,7 @@ syn match   gitcommitSummary	"^.\{0,50\}" contained containedin=gitcommitFirstLi
 syn match   gitcommitOverflow	".*" contained contains=@Spell
 syn match   gitcommitBlank	"^[^#].*" contained contains=@Spell
 
-if exists("g:gitcommit_cleanup") && g:gitcommit_cleanup == "scissors"
+if get(g:, "gitcommit_cleanup") is# "scissors"
   syn match gitcommitFirstLine	"\%^.*" nextgroup=gitcommitBlank skipnl
   syn region gitcommitComment start=/^# -\+ >8 -\+$/ end=/\%$/ contains=gitcommitDiff
 else

--- a/syntax/gitcommit.vim
+++ b/syntax/gitcommit.vim
@@ -18,11 +18,18 @@ endif
 syn include @gitcommitDiff syntax/diff.vim
 syn region gitcommitDiff start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|#\)\@=/ fold contains=@gitcommitDiff
 
-syn match   gitcommitFirstLine	"\%^[^#].*"  nextgroup=gitcommitBlank skipnl
 syn match   gitcommitSummary	"^.\{0,50\}" contained containedin=gitcommitFirstLine nextgroup=gitcommitOverflow contains=@Spell
 syn match   gitcommitOverflow	".*" contained contains=@Spell
 syn match   gitcommitBlank	"^[^#].*" contained contains=@Spell
-syn match   gitcommitComment	"^#.*"
+
+if exists("g:gitcommit_cleanup") && g:gitcommit_cleanup == "scissors"
+  syn match gitcommitFirstLine	"\%^.*" nextgroup=gitcommitBlank skipnl
+  syn region gitcommitComment start=/^# -\+ >8 -\+$/ end=/\%$/ contains=gitcommitDiff
+else
+  syn match gitcommitFirstLine	"\%^[^#].*" nextgroup=gitcommitBlank skipnl
+  syn match gitcommitComment	"^#.*"
+endif
+
 syn match   gitcommitHead	"^\%(#   .*\n\)\+#$" contained transparent
 syn match   gitcommitOnBranch	"\%(^# \)\@<=On branch" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite
 syn match   gitcommitOnBranch	"\%(^# \)\@<=Your branch .\{-\} '" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite


### PR DESCRIPTION
Lines starting with `#` usually behave as comments in a gitcommit file. This behavior is sometimes inconvenient. For example, it is hard to write markdown texts as commit descriptions because header lines (e.g., `### Some Title`) are treated as comments and are removed.

Git's `commit.cleanup scissors` configuration solves this problem. When `scissors` is enabled, first `# ------------------------ >8 ------------------------` line and its following lines are treated as comments, so you can start lines with `#`.

This PR makes vim-git support the `commit.cleanup scissors` configuration. Syntaxes for gitcommit change depending on `scissors` configuration.

You can switch enabled/disabled of `scissors` by `g:gitcommit_cleanup` variable in your vimrc. `scissors` is disabled as default. `let g:gitcommit_cleanup = "scissors"` enables `scissors`.
