### PR TITLE
Highlight diffs in --word-diff mode

### DIFF
--- a/syntax/git.vim
+++ b/syntax/git.vim
@@ -25,7 +25,9 @@ syn region gitDiff start=/^\%(@@ -\)\@=/ end=/^\%(diff --\%(git\|cc\|combined\) 
 syn region gitDiffMerge start=/^\%(diff --\%(cc\|combined\) \)\@=/ end=/^\%(diff --\|$\)\@=/ contains=@gitDiff
 syn region gitDiffMerge start=/^\%(@@@@* -\)\@=/ end=/^\%(diff --\|$\)\@=/ contains=@gitDiff
 syn match gitDiffAdded "^ \++.*" contained containedin=gitDiffMerge
+syn match gitDiffAdded "{+.*+}" contained containedin=gitDiff
 syn match gitDiffRemoved "^ \+-.*" contained containedin=gitDiffMerge
+syn match gitDiffRemoved "\[-.*-\]" contained containedin=gitDiff
 
 syn match  gitKeyword /^\%(object\|type\|tag\|commit\|tree\|parent\|encoding\)\>/ contained containedin=gitHead nextgroup=gitHash,gitType skipwhite
 syn match  gitKeyword /^\%(tag\>\|ref:\)/ contained containedin=gitHead nextgroup=gitReference skipwhite


### PR DESCRIPTION
So when viewing the results of `git diff --word-diff`, this plugin doesn't recognise the different style of diff indicator (where additions are enclosed in `{+ +}` and removals are enclosed in `[- -]`). This PR attempts to rectify that.

**However**, this doesn't actually work on my machine (macOS running either MacVim or Neovim). I can't figure out why. I'm hoping someone can take a look at this change and help me understand what the problem is.