### PR TITLE
Remove special casing of `.git/PULLREQ_EDITMSG`

### DIFF
--- a/ftdetect/git.vim
+++ b/ftdetect/git.vim
@@ -1,5 +1,5 @@
 " Git
-autocmd BufNewFile,BufRead *.git/{,modules/**/,worktrees/*/}{COMMIT_EDIT,PULLREQ_EDIT,TAG_EDIT,MERGE_,}MSG set ft=gitcommit
+autocmd BufNewFile,BufRead *.git/{,modules/**/,worktrees/*/}{COMMIT_EDIT,TAG_EDIT,MERGE_,}MSG set ft=gitcommit
 autocmd BufNewFile,BufRead *.git/config,.gitconfig,gitconfig,.gitmodules set ft=gitconfig
 autocmd BufNewFile,BufRead */.config/git/config                          set ft=gitconfig
 autocmd BufNewFile,BufRead *.git/modules/**/config                       set ft=gitconfig


### PR DESCRIPTION
It has been merged into vim-rhubarb as it is GitHub specific.

https://github.com/tpope/vim-rhubarb/pull/32