### PR TITLE
[syntax/gitcommit] See string width instead of character count

### DIFF
--- a/syntax/gitcommit.vim
+++ b/syntax/gitcommit.vim
@@ -18,7 +18,7 @@ endif
 syn include @gitcommitDiff syntax/diff.vim
 syn region gitcommitDiff start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|#\)\@=/ fold contains=@gitcommitDiff
 
-syn match   gitcommitSummary	"^.\{0,50\}" contained containedin=gitcommitFirstLine nextgroup=gitcommitOverflow contains=@Spell
+syn match   gitcommitSummary	".*\%<50v" contained containedin=gitcommitFirstLine nextgroup=gitcommitOverflow contains=@Spell
 syn match   gitcommitOverflow	".*" contained contains=@Spell
 syn match   gitcommitBlank	"^[^#].*" contained contains=@Spell
 


### PR DESCRIPTION
Multibyte string of 50 characters easily exceeds 50 columns.
So I think the pattern should use string width instead of character count.

# Before

![image](https://user-images.githubusercontent.com/48169/46078132-403d8f00-c1ce-11e8-8870-8475bcf7ab49.png)

# After

![image](https://user-images.githubusercontent.com/48169/46078070-171cfe80-c1ce-11e8-9efe-3f8a73c79397.png)
