### PR TITLE
Improve rebase

### DIFF
--- a/doc/ft-gitcommit-plugin.txt
+++ b/doc/ft-gitcommit-plugin.txt
@@ -3,3 +3,19 @@ GIT COMMIT                                              *ft-gitcommit-plugin*
 One command, :DiffGitCached, is provided to show a diff of the current commit
 in the preview window.  It is equivalent to calling "git diff --cached" plus
 any arguments given to the command.
+
+GIT REBASE                                              *ft-gitrebase-plugin*
+
+In a gitrebase filetype buffer, the following commands are provided:
+
+  `:Pick`     Changes the cursor line to a `pick` line.
+  `:Squash`   Changes the cursor line to a `squash` line
+  `:Edit`     Changes the cursor line to an `edit` line
+  `:Reword`   Changes the cursor line to a `reword` line
+  `:Fixup`    Changes the cursor line to a `fixup` line
+  `:Drop`     Changes the cursor line to a `drop` line
+  `:Cycle`    Cycles between the first 5 gitrebase commands
+
+To make the `:Cycle` command more useful, it might be mapped, e.g. >
+  nnoremap <buffer> <silent> S :Cycle<CR>
+<

--- a/syntax/gitrebase.vim
+++ b/syntax/gitrebase.vim
@@ -19,6 +19,7 @@ syn match   gitrebaseSquash "\v^s%(quash)=>" nextgroup=gitrebaseCommit skipwhite
 syn match   gitrebaseFixup  "\v^f%(ixup)=>"  nextgroup=gitrebaseCommit skipwhite
 syn match   gitrebaseExec   "\v^%(x|exec)>" nextgroup=gitrebaseCommand skipwhite
 syn match   gitrebaseDrop   "\v^d%(rop)=>"   nextgroup=gitrebaseCommit skipwhite
+syn match   gitrebaseBreak  "\v^b%(reak)=>"  nextgroup=gitrebaseCommit skipwhite
 syn match   gitrebaseSummary ".*"               contains=gitrebaseHash contained
 syn match   gitrebaseCommand ".*"                                      contained
 syn match   gitrebaseComment "^\s*#.*"             contains=gitrebaseHash
@@ -33,6 +34,7 @@ hi def link gitrebaseSquash         Type
 hi def link gitrebaseFixup          Special
 hi def link gitrebaseExec           Function
 hi def link gitrebaseDrop           Comment
+hi def link gitrebaseBreak          Macro
 hi def link gitrebaseSummary        String
 hi def link gitrebaseComment        Comment
 hi def link gitrebaseSquashError    Error


### PR DESCRIPTION
Add a couple of small improvements. 

Mostly to support the newly introduced `break` command for the interactive rebase.

One small change to the syntax highlighting was done. The default highlighting for the drop command has been changed to be a bit more noticeable, since the drop might be dangerous.

While at it, I added some documentation.