### PR TITLE
Ensure bulleted lists use hanging indents

### DIFF
--- a/ftplugin/gitcommit.vim
+++ b/ftplugin/gitcommit.vim
@@ -13,8 +13,10 @@ let b:did_ftplugin = 1
 
 setlocal comments=:# commentstring=#\ %s
 setlocal nomodeline tabstop=8 formatoptions+=tl textwidth=72
-setlocal formatoptions-=c formatoptions-=r formatoptions-=o formatoptions-=q
-let b:undo_ftplugin = 'setl modeline< tabstop< formatoptions< tw< com< cms<'
+setlocal formatoptions-=c formatoptions-=r formatoptions-=o formatoptions-=q formatoptions+=n
+setlocal formatlistpat+=\\\|^\\s*[-*+]\\s\\+
+
+let b:undo_ftplugin = 'setl modeline< tabstop< formatoptions< tw< com< cms< formatlistpat<'
 
 if exists("g:no_gitcommit_commands") || v:version < 700
   finish


### PR DESCRIPTION
Hanging indents currently work for numerical lists, not bulleted. This
change adjusts the `formatoption`s and `formatlistpat` options to recognise
bulleted list headers.