### PR TITLE
Highlight summary overflow after 50 characters

### DIFF
--- a/syntax/gitcommit.vim
+++ b/syntax/gitcommit.vim
@@ -18,7 +18,7 @@ endif
 syn include @gitcommitDiff syntax/diff.vim
 syn region gitcommitDiff start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|#\)\@=/ fold contains=@gitcommitDiff
 
-syn match   gitcommitSummary	".*\%<50v" contained containedin=gitcommitFirstLine nextgroup=gitcommitOverflow contains=@Spell
+syn match   gitcommitSummary	"^.*\%<51v." contained containedin=gitcommitFirstLine nextgroup=gitcommitOverflow contains=@Spell
 syn match   gitcommitOverflow	".*" contained contains=@Spell
 syn match   gitcommitBlank	"^[^#].*" contained contains=@Spell
 


### PR DESCRIPTION
## The problem

The summary overflow highlighting used to start after 50 characters, but now starts after 48. `git bisect` attributes it to 44cc3b91b713ce29e726a0ca526628fb934f5013.

Before:

    A summary message that is fifty-one characters long
    --------------------------------------------------X

After:

    A summary message that is fifty-one characters long
    ------------------------------------------------XXX

## The cause

The current pattern (`.*\%<50v`) matches in columns _less than_ 50, so the last match is in column 49. Additionally, since it's a zero-width match, the last matched character is the one in column 48.

## The solution

Follow the recipe from the regex manual for `/\%<v`:

- Use 51 as the column, so the last (zero-width) match is in column 50

- Add a dot, to match the character in column 50

Also, anchor it to the beginning of the line.