### PR TITLE
Highlight escapes in git config as Special

### DIFF
--- a/syntax/gitconfig.vim
+++ b/syntax/gitconfig.vim
@@ -30,7 +30,7 @@ hi def link gitconfigBoolean		Boolean
 hi def link gitconfigNumber		Number
 hi def link gitconfigString		String
 hi def link gitconfigDelim		Delimiter
-hi def link gitconfigEscape		Delimiter
+hi def link gitconfigEscape		Special
 hi def link gitconfigError		Error
 
 let b:current_syntax = "gitconfig"


### PR DESCRIPTION
Hi,

I’ve noticed that, most of the time, escapes are highlighted using `Special`. Git config does not follow this pattern, however. Please let me know if there is a reason for why it is the way it is.

Thanks.