### PR TITLE
syntax: gitcommit, gitsendemail: highlight pseudo-headers

### DIFF
--- a/syntax/gitcommit.vim
+++ b/syntax/gitcommit.vim
@@ -30,6 +30,9 @@ else
   syn match gitcommitComment	"^#.*"
 endif
 
+" list extracted from https://www.kernel.org/doc/html/latest/process/submitting-patches.html#when-to-use-acked-by-cc-and-co-developed-by
+syn match   gitcommitPseudoHeader "^\(Signed-off-by\|Acked-by\|Cc\|Co-Developed-by\|Co-authored-by\|Fixes\|Reported-by\|Reviewed-by\|Suggested-by\|Tested-by\):\s*.*$"
+
 syn match   gitcommitHash	"\<\x\{40,}\>" contains=@NoSpell display
 syn match   gitcommitHead	"^\%(#   .*\n\)\+#$" contained transparent
 syn match   gitcommitOnBranch	"\%(^# \)\@<=On branch" contained containedin=gitcommitComment nextgroup=gitcommitBranch skipwhite
@@ -64,6 +67,7 @@ syn match   gitcommitWarning		"^\%(no changes added to commit\|nothing \%(added 
 
 hi def link gitcommitSummary		Keyword
 hi def link gitcommitComment		Comment
+hi def link gitcommitPseudoHeader	Type
 hi def link gitcommitUntracked		gitcommitComment
 hi def link gitcommitDiscarded		gitcommitComment
 hi def link gitcommitSelected		gitcommitComment

--- a/syntax/gitsendemail.vim
+++ b/syntax/gitsendemail.vim
@@ -17,7 +17,10 @@ syn case match
 
 syn match   gitsendemailComment "\%^From.*#.*"
 syn match   gitsendemailComment "^GIT:.*"
+" list extracted from https://www.kernel.org/doc/html/latest/process/submitting-patches.html#when-to-use-acked-by-cc-and-co-developed-by
+syn match   gitsendemailPseudoHeader "^\(Signed-off-by\|Acked-by\|Cc\|Co-Developed-by\|Co-authored-by\|Fixes\|Reported-by\|Reviewed-by\|Suggested-by\|Tested-by\):\s*.*$"
 
 hi def link gitsendemailComment Comment
+hi def link gitsendemailPseudoHeader mailHeaderKey
 
 let b:current_syntax = "gitsendemail"


### PR DESCRIPTION
Highlight [frequently used pseudo headers](https://www.kernel.org/doc/html/latest/process/submitting-patches.html#when-to-use-acked-by-cc-and-co-developed-by) in the log message body.

Following up from vim/vim#6139, this seems to be the canonical source.