### PR TITLE
Rebase: highlight empty commits

### DIFF
--- a/syntax/gitrebase.vim
+++ b/syntax/gitrebase.vim
@@ -26,6 +26,8 @@ syn match   gitrebaseLabel  "\v^l(abel)=>"   nextgroup=gitrebaseName skipwhite
 syn match   gitrebaseReset  "\v^(t|reset)=>" nextgroup=gitrebaseName skipwhite
 syn match   gitrebaseSummary ".*"               contains=gitrebaseHash contained
 syn match   gitrebaseCommand ".*"                                      contained
+syn match   gitrebaseEmpty   " \zs# empty$"        containedin=gitrebaseSummary contained
+syn match   gitrebaseComment "# "                  containedin=gitrebaseEmpty   contained
 syn match   gitrebaseComment "^\s*#.*"             contains=gitrebaseHash
 syn match   gitrebaseSquashError "\v%^%(s%(quash)=>|f%(ixup)=>)" nextgroup=gitrebaseCommit skipwhite
 syn match   gitrebaseMergeOption "\v-[Cc]>"  nextgroup=gitrebaseMergeCommit skipwhite contained
@@ -48,6 +50,7 @@ hi def link gitrebaseMerge          Exception
 hi def link gitrebaseLabel          Label
 hi def link gitrebaseReset          Keyword
 hi def link gitrebaseSummary        String
+hi def link gitrebaseEmpty          Error
 hi def link gitrebaseComment        Comment
 hi def link gitrebaseSquashError    Error
 hi def link gitrebaseMergeCommit    gitrebaseCommit


### PR DESCRIPTION
When rebasing, `git` alters the commit message of empty commits.
This can be easy to miss.

Add some highlighting for the ` # empty` comment.
By default, I've linked this to the `Error` colour.

![empty](https://user-images.githubusercontent.com/76760/116085535-d2fc7e00-a696-11eb-9349-5710aad790cf.png)

Update: The 'empty' string seems to be fixed, whatever your locale.